### PR TITLE
Replace Jira tab with a message `div` on Drupal.org (and a couple of other updates)

### DIFF
--- a/background.js
+++ b/background.js
@@ -67,10 +67,6 @@ function combineDrupalJira(drupalOrgIssues, jiraIssues) {
         return 'phenaproxima';
       case '3685174':
         return 'yash.rode';
-      case '3688861':
-        return 'Theresa.Grannum';
-      case '3685158':
-        return 'omkarpodey';
       case '240860':
         return 'tedbow';
       default:

--- a/content-styles.css
+++ b/content-styles.css
@@ -1,3 +1,14 @@
+#jira-issue-message {
+  margin: 0 0 1.38462em 0;
+  background-color: #e9f2fe;
+  background-image: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><defs><clipPath id="clip0_2967_1690"><rect width="24" height="24" fill="white"/></clipPath></defs><g clip-path="url(%23clip0_2967_1690)"><path d="M19.9721 3.40039H10.1797C10.1797 5.79593 12.1608 7.74579 14.5948 7.74579H16.4061V9.44496C16.4061 11.8405 18.3872 13.7904 20.8212 13.7904V4.23605C20.8212 3.76251 20.4533 3.40039 19.9721 3.40039Z" fill="%231868DB"></path><path d="M15.1323 8.19141H5.33984C5.33984 10.5869 7.32098 12.5368 9.75494 12.5368H11.5663V14.2638C11.5663 16.6594 13.5474 18.6092 15.9814 18.6092V9.02706C15.9814 8.58138 15.6134 8.19141 15.1323 8.19141Z" fill="%231868DB"></path><path d="M10.2925 13.0107H0.5C0.5 15.4063 2.48113 17.3561 4.91509 17.3561H6.72641V19.0553C6.72641 21.4509 8.70755 23.4007 11.1415 23.4007V13.8464C11.1415 13.3729 10.7453 13.0107 10.2925 13.0107Z" fill="%231868DB"></path></g></svg>');
+  background-position: 8px;
+  background-repeat: no-repeat;
+}
+#jira-issue-message a {
+  background-color: inherit;
+  border: none;
+}
 div.jira-issue a {
   text-decoration: none !important;
   border: 1px solid;

--- a/drupal-content-script.js
+++ b/drupal-content-script.js
@@ -4,10 +4,10 @@
   src = chrome.runtime.getURL("common.js");
   const { utils } = await import(src);
 
-
-  var tabs = document.getElementById("tabs");
   var issueIds = [];
   var pageIssueId;
+  var url = document.URL;
+
   function createPlaceHolder(issueId) {
     var div = document.createElement("div");
     div.className = `jira-issue jira-issue-${issueId}`;
@@ -15,23 +15,32 @@
     return div;
   }
 
-// Add placeholder for tabs section
-  if (tabs) {
-    var tabLists = tabs.getElementsByTagName("ul");
-    if (tabLists) {
-      var tabList = tabLists.item(0);
-      var node = document.createElement("li");
-      var url = document.URL;
-      const regex =
-          /https:\/\/www\.drupal\.org\/project\/(automatic_updates|experience_builder)\/issues\/.*/g;
-      if (url.match(regex)) {
-        var issueId = utils.getIssueIdFromUrl(url);
-        pageIssueId = issueId;
-        issueIds.push(issueId);
-        node.appendChild(createPlaceHolder(issueId));
-        tabList.appendChild(node);
-      }
-    }
+// Add placeholder for message div on issue page
+  const regex =
+      /https:\/\/www\.drupal\.org\/project\/(automatic_updates|experience_builder)\/issues\/.*/g;
+  if (url.match(regex)) {
+    var issueId = utils.getIssueIdFromUrl(url);
+    pageIssueId = issueId;
+    issueIds.push(issueId);
+
+    let messageDiv = document.createElement("div");
+    messageDiv.id = "jira-issue-message";
+    messageDiv.className = `messages jira-issue jira-issue-${issueId}`;
+
+    // Create the placeholder link
+    let link;
+    link = document.createElement("a");
+    link.setAttribute("href", jiraConfig.jira_create_url);
+    link.title = "Create a Jira issue for this drupal.org issue";
+    link.innerText = "⏱";
+
+    // Add the link to the message div
+    messageDiv.appendChild(link);
+
+    // Insert the new div after any other messages, right before the #content-inner div
+    const parentElement = document.querySelector("#content");
+    const referenceElement = document.querySelector("#content-inner");
+    parentElement.insertBefore(messageDiv, referenceElement);
   }
   var links = document.querySelectorAll("a");
 

--- a/drupal-content-script.js
+++ b/drupal-content-script.js
@@ -23,7 +23,7 @@
       var node = document.createElement("li");
       var url = document.URL;
       const regex =
-          /https:\/\/www\.drupal\.org\/project\/automatic_updates\/issues\/.*/g;
+          /https:\/\/www\.drupal\.org\/project\/(automatic_updates|experience_builder)\/issues\/.*/g;
       if (url.match(regex)) {
         var issueId = utils.getIssueIdFromUrl(url);
         pageIssueId = issueId;


### PR DESCRIPTION
Would you be open to a feature change (and a couple of updates), @tedbow? This does three things:

1. Convert the Drupal.org Jira issue tabs to `message` `div`s. It leverages Drupal.org's styles a little more and "fixes" something that (respectfully) I thought was broken, at first.

	- ⬆️ **Before:**

		<img alt="Before" width="646"  src="https://github.com/user-attachments/assets/7dfe2d99-1585-4cb4-8654-71f5b8adffc1" />

	- ⬇️ **After:**

		<img alt="After" width="646" src="https://github.com/user-attachments/assets/a2b505ff-a066-4f74-8d62-2ad06c3c9ff1" />

2. It adds `experience_builder` to the project match.

3. Removed a couple of former developers.
