### PR TITLE
Add feature toggles and improve config file error-handling

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -7,5 +7,9 @@ const jiraConfig = {
     "jira_base_url": "https://my-domain.atlassian.net/",
     "show_sprint_value": 0; //set this to true if you want to show sprint as well
     "sprint_custom_field_id": "customfield_xxxxx"; //set this value to your custom field value from JIRA
+    // Enable/disable enhancements to drupal.org.
+    "enable_drupalorg_enhancements": true,
+    // Enable/disable enhancements to Jira at `jira_base_url`.
+    "enable_jira_enhancements": true
 };
 export { jiraConfig };

--- a/config.example.js
+++ b/config.example.js
@@ -5,8 +5,8 @@ const jiraConfig = {
     "jira_create_url":
         "https://my-domain.atlassian.net/secure/CloneIssueDetails!default.jspa?id=12345",
     "jira_base_url": "https://my-domain.atlassian.net/",
-    "show_sprint_value": 0; //set this to true if you want to show sprint as well
-    "sprint_custom_field_id": "customfield_xxxxx"; //set this value to your custom field value from JIRA
+    "show_sprint_value": 0, // Set this to true if you want to show sprint as well
+    "sprint_custom_field_id": "customfield_xxxxx", // Set this value to your custom field value from JIRA
     // Enable/disable enhancements to drupal.org.
     "enable_drupalorg_enhancements": true,
     // Enable/disable enhancements to Jira at `jira_base_url`.

--- a/drupal-content-script.js
+++ b/drupal-content-script.js
@@ -1,8 +1,22 @@
 (async () => {
-  let src = chrome.runtime.getURL("config.js");
-  const { jiraConfig } = await import(src);
-  src = chrome.runtime.getURL("common.js");
-  const { utils } = await import(src);
+  let configSrc = chrome.runtime.getURL("config.js");
+  let commonSrc = chrome.runtime.getURL("common.js");
+
+  let jiraConfig = {};
+
+  try {
+    ({ jiraConfig } = await import(configSrc));
+  } catch (error) {
+    console.error(`Failed to import '${configSrc}': ${error.message}`);
+    if (error.message.includes("Failed to fetch dynamically imported module")) {
+      console.error(
+        "Config file 'config.js' not found in jira-drupalorg-chrome extension. See 'config.example.js' in its root directory for instructions for creating one."
+      );
+    }
+    return;
+  }
+
+  const { utils } = await import(commonSrc);
 
   var issueIds = [];
   var pageIssueId;

--- a/drupal-content-script.js
+++ b/drupal-content-script.js
@@ -16,6 +16,15 @@
     return;
   }
 
+  // Enable/disable this feature in `config.js`.
+  if (
+    jiraConfig &&
+    jiraConfig.hasOwnProperty('enable_drupalorg_enhancements') &&
+    jiraConfig.enable_drupalorg_enhancements === false
+  ) {
+    return;
+  }
+
   const { utils } = await import(commonSrc);
 
   var issueIds = [];

--- a/jira-content-script.js
+++ b/jira-content-script.js
@@ -1,8 +1,22 @@
 (async () => {
-    let src = chrome.runtime.getURL("config.js");
-    const { jiraConfig } = await import(src);
-    src = chrome.runtime.getURL("common.js");
-    const { utils } = await import(src);
+    let configSrc = chrome.runtime.getURL("config.js");
+    let commonSrc = chrome.runtime.getURL("common.js");
+
+    let jiraConfig = {};
+
+    try {
+      ({ jiraConfig } = await import(configSrc));
+    } catch (error) {
+      console.error(`Failed to import '${configSrc}': ${error.message}`);
+      if (error.message.includes("Failed to fetch dynamically imported module")) {
+        console.error(
+          "Config file 'config.js' not found in jira-drupalorg-chrome extension. See 'config.example.js' in its root directory for instructions for creating one."
+        );
+      }
+      return;
+    }
+
+    const { utils } = await import(commonSrc);
 
     //.aui-header-primary .aui-nav
     document.querySelectorAll('#ak-jira-navigation').forEach(function (el){

--- a/jira-content-script.js
+++ b/jira-content-script.js
@@ -16,6 +16,15 @@
       return;
     }
 
+    // Enable/disable this feature in `config.js`.
+    if (
+      jiraConfig &&
+      jiraConfig.hasOwnProperty('enable_jira_enhancements')
+      && jiraConfig.enable_jira_enhancements === false
+    ) {
+      return;
+    }
+
     const { utils } = await import(commonSrc);
 
     //.aui-header-primary .aui-nav


### PR DESCRIPTION
@tedbow, this adds a feature toggle to enable/disable the functionality in Jira and on Drupal.org, respectively. Since the Jira integration no longer works, I wanted to be able to turn it off, and I added a toggle for Drupal.org just for symmetry. It also adds a little error-handling in case `config.js` is missing. You know, for Wim. 😉

Is the code a little duplicative and perhaps slightly inelegant? Perhaps. But we don't have time to make things pretty--we have crime to fight and a city to save!

